### PR TITLE
Pseudo-ID and auto ID improvements

### DIFF
--- a/class/Object.lua
+++ b/class/Object.lua
@@ -121,6 +121,14 @@ function _M:getDisplayColor()
     end
 end
 
+---Gets the pseudo ID feeling of the object
+function _M:getPseudoIdFeeling()
+    if self.cursed then return "cursed"
+    elseif self.egoed and self.greater_ego then return "excellent"
+    elseif self.egoed then return "magical"
+    else return "average"
+    end
+end
 
 --- Gets the full name of the object
 function _M:getName(t)
@@ -132,11 +140,7 @@ function _M:getName(t)
     if self.identified == false and not t.force_id and self:getUnidentifiedName() then name = self:getUnidentifiedName() end
     
     if self.pseudo_id == true and self.identified == false and not t.force_id then --and self:getUnidentifiedName() then
-        if self.cursed then name = name.." {cursed}"
-        elseif self.egoed and self.greater_ego then name = name.." {excellent}"
-        elseif self.egoed then name = name.." {magical}"
-        else name = name.." {average}"
-        end
+        name = ("%s {%s}"):format(name, self:getPseudoIdFeeling())
     end
 
 
@@ -288,7 +292,7 @@ function _M:on_prepickup(who, idx)
         end 
     end
     if self.pseudo_id == true and self.cursed then 
-        game.log("You recognize the item as cursed and destroy it")
+        game.log("You recognize the item as cursed and destroy it.")
         game.level.map:removeObject(who.x, who.y, idx) return true 
     end
     

--- a/class/Player.lua
+++ b/class/Player.lua
@@ -646,31 +646,37 @@ function _M:setCountID()
 end
 
 function _M:pseudoID()
-local list = {}
-        local inven = game.player:getInven("INVEN")
-        i = rng.range(1, #inven)
-        local o = inven[i]
-          --add a check for empty inventory
-          if o and o.pseudo_id == false then
-            local check = self:skillCheck("intuition", 10, true)
-                        if check then 
-                          o.pseudo_id = true 
-                        end        
-          else end
+    local can_id = {}
+    self:inventoryApplyAll(function(inven, item, o)
+        if not o.pseudo_id then
+            can_id[#can_id+1] = o
+        end
+    end)
+
+    if #can_id == 0 then return end
+
+    if self:skillCheck("intuition", 10, true) then
+        local o = rng.table(can_id)
+        o.pseudo_id = true
+        game.logPlayer(self, ("You feel that your %s is %s."):format(o:getUnidentifiedName(), o:getPseudoIdFeeling()))
+    end
 end
 
 function _M:autoID()
-  local list = {}
-        local inven = game.player:getInven("INVEN")
-        i = rng.range(1, #inven)
-        local o = inven[i]
-          if o and o.identified == false and o.pseudo_id == true then
-            local check = self:skillCheck("intuition", 25, true)
-                        if check then 
-                          o.identified = true 
-                          game.logSeen(game.player, "Identified: %s", o.name)
-                        end        
-            else end
+    local can_id = {}
+    self:inventoryApplyAll(function(inven, item, o)
+        if o.pseudo_id and not o.identified then
+            can_id[#can_id+1] = o
+        end
+    end)
+
+    if #can_id == 0 then return end
+
+    if self:skillCheck("intuition", 25, true) then
+        local o = rng.table(can_id)
+        o.identified = true 
+        game.logPlayer(self, "Identified: %s", o.name)
+    end
 end
 
 


### PR DESCRIPTION
Pseudo-ID and auto ID now operate on equipped items as well as regular inventory, and they don't try to ID already ID'ed items.

Pseudo-ID now prints a message on success.

NOTE: After these changes, items get pseudo-ID'ed very quickly. You may want to increase the pseudo-ID counters to compensate for it being so much easier.
