### PR TITLE
Egos

### DIFF
--- a/class/Ego.lua
+++ b/class/Ego.lua
@@ -44,7 +44,7 @@ function _M:allowedEgosFor(o, good, side)
     end]]
 
 	if not o.egos then return {} end
-	self.egos_def = self:loadList(o.egos)
+	self.egos_def = self:loadList(o.egos, true)
 
     for _, e in ipairs(self.egos_def) do
     local ok = true

--- a/class/Ego.lua
+++ b/class/Ego.lua
@@ -5,7 +5,7 @@
 
 require 'engine.class'
 local Entity = require 'engine.Entity'
-local Zone = require 'engine.Zone'
+local Zone = require 'mod.class.Zone'
 
 module(..., package.seeall, class.inherit(Entity))
 
@@ -108,25 +108,8 @@ function _M:placeForcedEgos(e)
     if not e.force_ego then return end
     if type(e.force_ego) == 'string' then e.force_ego = { e.force_ego } end
 
-    -- Duplicated from Zone:finishEntity
     for ie, ego in ipairs(e.force_ego) do
-        ego = self.egos_def[ego]
-        ego = ego:clone()
-        local newname
-        if ego.prefix then newname = ego.name .. e.name
-        else newname = e.name .. ego.name end
-        print("applying ego", ego.name, "to ", e.name, "::", newname, "///", e.unided_name, ego.unided_name)
-        ego.unided_name = nil
-        ego.__CLASSNAME = nil
-        -- The ego requested instant resolving before merge ?
-        if ego.instant_resolve then ego:resolve(nil, nil, e) end
-        ego.instant_resolve = nil
-        -- Void the uid, we dont want to erase the base entity's one
-        ego.uid = nil
-        -- Merge according to Object's ego rules.
-        table.ruleMergeAppendAdd(e, ego, Zone.ego_rules[type] or {})
-        e.name = newname
-        e.egoed = true
+        Zone:applyEgo(e, self.egos_def[ego])
     end
     -- Re-resolve with the (possibly) new resolvers
     e:resolve()

--- a/class/Ego.lua
+++ b/class/Ego.lua
@@ -5,6 +5,7 @@
 
 require 'engine.class'
 local Entity = require 'engine.Entity'
+local Zone = require 'engine.Zone'
 
 module(..., package.seeall, class.inherit(Entity))
 
@@ -112,21 +113,32 @@ function _M:tryAddEgos(o, good, pass2)
 
 end
 
-function _M:placeForcedEgos(o)
-  if not o.force_ego then return end
-  if type(o.force_ego) == 'string' then o.force_ego = { o.force_ego } end
-  for _, id in ipairs(o.force_ego) do
-    local e = self.egos_def[id]
-    if e then
-      o.ego_names = o.ego_names or {}
-      local which = e.prefix and 'prefix' or 'suffix'
-      o.ego_names[which] = id
-      print(("[EGO] forcing %s ego '%s'"):format(which, e.name))
+function _M:placeForcedEgos(e)
+    if not e.force_ego then return end
+    if type(e.force_ego) == 'string' then e.force_ego = { e.force_ego } end
 
-    else
-      print('[EGO] no such ego '..id)
+    -- Duplicated from Zone:finishEntity
+    for ie, ego in ipairs(e.force_ego) do
+        ego = self.egos_def[ego]
+        ego = ego:clone()
+        local newname
+        if ego.prefix then newname = ego.name .. e.name
+        else newname = e.name .. ego.name end
+        print("applying ego", ego.name, "to ", e.name, "::", newname, "///", e.unided_name, ego.unided_name)
+        ego.unided_name = nil
+        ego.__CLASSNAME = nil
+        -- The ego requested instant resolving before merge ?
+        if ego.instant_resolve then ego:resolve(nil, nil, e) end
+        ego.instant_resolve = nil
+        -- Void the uid, we dont want to erase the base entity's one
+        ego.uid = nil
+        -- Merge according to Object's ego rules.
+        table.ruleMergeAppendAdd(e, ego, Zone.ego_rules[type] or {})
+        e.name = newname
+        e.egoed = true
     end
-  end
+    -- Re-resolve with the (possibly) new resolvers
+    e:resolve()
 end
 
 -- Static.

--- a/class/Ego.lua
+++ b/class/Ego.lua
@@ -11,16 +11,6 @@ module(..., package.seeall, class.inherit(Entity))
 
 _M.egos_def = {}
 
--- Static
-function _M:loadEgos(f)
-  self.egos_def = self:loadList(f)
-end
-
--- Static
-function _M:get(id)
-  return egos_def[id]
-end
-
 -- - 'good' can be true for only good egos, false for only cursed egos, or
 --   nil for both.
 -- - 'side' can be 'prefix' or 'suffix' for only the corresponding egos, or
@@ -53,7 +43,8 @@ function _M:allowedEgosFor(o, good, side)
         end
     end]]
 
-
+	if not o.egos then return {} end
+	self.egos_def = self:loadList(o.egos)
 
     for _, e in ipairs(self.egos_def) do
     local ok = true

--- a/data/general/objects/properties/armor.lua
+++ b/data/general/objects/properties/armor.lua
@@ -163,7 +163,7 @@ newEntity { define_as = "EGO_GREATER_SHADOW",
 }
 
 newEntity { define_as = "EGO_SILENT",
-	name = " of silent moves ", suffix = true,
+	name = " of silent moves", suffix = true,
 	keywords = {silent=true},
 	level_range = {5, nil},
 	rarity = 8,
@@ -580,7 +580,7 @@ newEntity {
 
 --Based on Angband's
 newEntity {
-	name = "dwarven", suffix = false,
+	name = "dwarven", prefix = true,
 --	keywords = {bonus=true},
 	level_range = {10, 30},
 	rarity = 15,

--- a/data/general/objects/properties/charged.lua
+++ b/data/general/objects/properties/charged.lua
@@ -48,7 +48,7 @@ end
 }
 
 newEntity{
-    name = "of burning hands", suffix = true,
+    name = " of burning hands", suffix = true,
     level_range = {1, 10},
     rarity = 5,
     cost = resolvers.value{platinum=450},
@@ -71,7 +71,7 @@ end
 
 
 --[[newEntity{
-    name = "of sleep", suffix = true,
+    name = " of sleep", suffix = true,
     level_range = {1, 10},
     rarity = 5,
     cost = resolvers.value{platinum=450},

--- a/data/general/objects/properties/wondrous_items.lua
+++ b/data/general/objects/properties/wondrous_items.lua
@@ -631,7 +631,7 @@ newEntity{
 }
 
 newEntity{
-	name = "of the Spur", suffix = true,
+	name = " of the Spur", suffix = true,
 	level_range = {10, 30},
 	rarity = 5,
 --	cost = 16000,
@@ -742,7 +742,7 @@ newEntity{
 }
 
 newEntity{
-	name = "of the Bat", suffix = true,
+	name = " of the Bat", suffix = true,
 	level_range = {10, 30},
 	rarity = 5,
 --	cost = 26000,

--- a/dialogs/debug/CreateItem2.lua
+++ b/dialogs/debug/CreateItem2.lua
@@ -23,7 +23,7 @@ function _M:init()
   self.c_items = List.new {
     width = 400,
     nb_items = 10,
---    display_prop = 'display',
+    display_prop = 'display',
     list = self.list,
     scrollbar = true,
     fct = function(item) self:selectItem(item) end,
@@ -98,7 +98,8 @@ function _M:setDisplayText(item, which)
     sel = (item.id and item.id == self.ego_names[which]) or
       (not item.id and not self.ego_names[which])
   end
-  item.display = sel and '#{bold}#'..item.name..'#{normal}#' or item.name
+  local name = item.base_display or item.name
+  item.display = sel and '#{bold}#'..name..'#{normal}#' or name
 end
 
 function _M:selectItem(item)
@@ -188,11 +189,9 @@ function _M:generateList()
 
     for i, e in ipairs(game.zone.object_list) do
         if e.name and e.rarity then
-            local color
-            if e.unique then color = {255, 215, 0}
-            else color = {255, 255, 255} end
+            local display = (e.unique and '#ffd700#' or '#ffffff#') .. e.name .. '#LAST#'
 
-            list[#list+1] = {name=e.name, unique=e.unique, e=e}
+            list[#list+1] = {name=e.name, display=display, base_display=display, unique=e.unique, e=e}
         end
     end
     table.sort(list, function(a,b)

--- a/dialogs/debug/CreateItem2.lua
+++ b/dialogs/debug/CreateItem2.lua
@@ -21,7 +21,7 @@ function _M:init()
   self:generateList()
 
   self.c_items = List.new {
-    width = 400,
+    width = 350,
     nb_items = 10,
     display_prop = 'display',
     list = self.list,
@@ -133,14 +133,11 @@ function _M:setupEgoLists()
   local pfx_egos = { { name = 'No prefix ego' } }
   local sfx_egos = { { name = 'No suffix ego' } }
 
-  for _, ego in ipairs(Ego:allowedEgosFor(self.sel_item.e)) do
-    if ego.define_as then
+  for id, ego in ipairs(Ego:allowedEgosFor(self.sel_item.e)) do
     local dst = ego.prefix and pfx_egos or ego.suffix and sfx_egos
-    local item = { name = ego.name, id = ego.define_as }
-    dst[item.id] = item
+    local item = { name = ego.name, id = id }
     table.insert(dst, item)
     game.log("Inserted ego: "..item.name)
-    end
   end
   self.ego_names = {}
   for _, item in ipairs(pfx_egos) do self:setDisplayText(item, 'prefix') end

--- a/dialogs/debug/CreateItem2.lua
+++ b/dialogs/debug/CreateItem2.lua
@@ -22,7 +22,7 @@ function _M:init()
 
   self.c_items = List.new {
     width = 350,
-    nb_items = 10,
+    nb_items = 20,
     display_prop = 'display',
     list = self.list,
     scrollbar = true,
@@ -30,7 +30,7 @@ function _M:init()
   }
   self.c_pfx_egos = List.new {
     width = 200,
-    nb_items = 10,
+    nb_items = 15,
     display_prop = 'display',
     list = {},
     scrollbar = true,
@@ -38,7 +38,7 @@ function _M:init()
   }
   self.c_sfx_egos = List.new {
     width = 200,
-    nb_items = 10,
+    nb_items = 15,
     display_prop = 'display',
     list = {},
     scrollbar = true,
@@ -56,8 +56,8 @@ function _M:init()
     text = 'Create',
     fct = function() self:createItem() end,
   }
-  self.c_cancel = Button.new {
-    text = 'Cancel',
+  self.c_close = Button.new {
+    text = 'Close',
     fct = function() self.key:triggerVirtual('EXIT') end,
   }
 
@@ -67,8 +67,8 @@ function _M:init()
     { left=0, top=self.c_items.h, ui=self.c_nitems },
     { right=0, top=0, ui=self.c_sfx_egos },
     { right=self.c_sfx_egos.w, top=0, ui=self.c_pfx_egos },
-    { right=0, bottom=0, ui=self.c_cancel },
-    { right=self.c_cancel.w, bottom=0, ui=self.c_create },
+    { right=0, bottom=0, ui=self.c_close },
+    { right=self.c_close.w, bottom=0, ui=self.c_create },
   }
 
   self:setupUI()
@@ -161,9 +161,6 @@ end
 
 function _M:createItem()
   if not self:readyToCreate() then return end
-  game:unregisterDialog(self)
-
-    
 
     local qty = self.c_nitems.number
   --  local o = game.zone:finishEntity(game.level, 'object', self.sel_item.e)
@@ -178,6 +175,7 @@ function _M:createItem()
     Ego:placeForcedEgos(o)
 
     game.zone:addEntity(game.level, o, 'object', game.player.x, game.player.y)
+	game.log('Created '..o.name)
 end
 
 --Generate item list

--- a/dialogs/debug/DebugMenu.lua
+++ b/dialogs/debug/DebugMenu.lua
@@ -132,9 +132,9 @@ function _M:generateList()
 --	list[#list+1] = {name="Grant/Alter Quests", dialog="GrantQuest"}
 	list[#list+1] = {name="Level spots", dialog="LevelSpotsTracker"}
 	list[#list+1] = {name="Summon Creature", dialog="SummonCreature"}
---	list[#list+1] = {name="Create Item", dialog="CreateItem2"}
+	list[#list+1] = {name="Create Item", dialog="CreateItem2"}
 --	list[#list+1] = {name="Create Item", dialog="CreateItem"}
-	list[#list+1] = {name="Create Item", dialog="CreateItem3"}
+--	list[#list+1] = {name="Create Item", dialog="CreateItem3"}
 --	list[#list+1] = {name="Alter Faction", dialog="AlterFaction"}
 	list[#list+1] = {name="Create Trap", dialog="CreateTrap"}
 	list[#list+1] = {name="Create Terrain", dialog="CreateTerrain"}

--- a/init.lua
+++ b/init.lua
@@ -20,7 +20,7 @@ short_name = "veins"
 author = { "Zireael", "x" }
 homepage = "https://github.com/Zireael07/The-Veins-of-the-Earth"
 version = {0,26,0}
-engine = {1,2,4,"te4"}
+engine = {1,2,5,"te4"}
 description = [[
 #SANDY_BROWN# BETA 6.6#LAST#
 In DarkGod's words, #GOLD#"a fantasy d20-themed dungeon crawler"#LAST#.

--- a/load.lua
+++ b/load.lua
@@ -38,7 +38,6 @@ local PlayerLore = require "mod.class.interface.PlayerLore"
 local UIBase = require "engine.ui.Base"
 
 local Object = require 'mod.class.Object'
-local Ego = require "mod.class.Ego"
 
 -- Init settings
 config.settings.veins = config.settings.veins or {}
@@ -227,9 +226,6 @@ Store:loadStores("/data/general/stores/general.lua")
 PlayerLore:loadDefinition("/data/lore/lore.lua")
 
 Object:loadFlavors('/data/object_flavors.lua')
-
--- Object egos
-Ego:loadEgos('/data/general/ego/egos.lua')
 
 --More shenanigans
 


### PR DESCRIPTION
The "Create item" debug menu item can now correctly apply egos (I think). Maybe this will remove a bit of the need for DG to add an "apply ego" function to T-Engine / ToME.

Some further cleanup may be possible; I don't think that Ego.lua's `tryAddEgo` or `resolveEgo` or the `data/general/ego` subdirectory are used any more, but I didn't want to delete those without checking with you.